### PR TITLE
Allow multiple instances of client

### DIFF
--- a/coffee/adapter.coffee
+++ b/coffee/adapter.coffee
@@ -1,4 +1,8 @@
-adapter = null
+class Adapter
+  constructor: (fhir)->
+    @adapter = null
+    @fhir = fhir
+  set:  (x) -> @adapter = x
+  get:  ()  -> @adapter
 
-exports.setAdapter =  (x)-> adapter = x
-exports.getAdapter =  ()-> adapter
+module.exports = Adapter

--- a/coffee/adapters/jqFhirImpl.coffee
+++ b/coffee/adapters/jqFhirImpl.coffee
@@ -1,20 +1,20 @@
 fhir = require('../fhir.js')
 $ = require('jquery')
+instance = fhir()
 
 adapter = {
   "http": (q)->
-    console.log "Requesting", q.method, q.url, q.headers
     a = $.ajax {type: q.method, url: q.url, headers: q.headers}
     a.done(q.success) if q.success
     a.fail(q.error) if q.error
 }
 
-fhir.setAdapter adapter
+instance.adapter.set adapter
 
-exports.fhir = fhir
-exports.configure = fhir.configure
+exports.fhir = instance
+exports.config = instance.config
 
 exports.search = (type, query) ->
   ret = $.Deferred()
-  fhir.search(type, query, ret.resolve, ret.reject)
+  instance.search(type, query, ret.resolve, ret.reject)
   ret

--- a/coffee/adapters/ngFhirImpl.coffee
+++ b/coffee/adapters/ngFhirImpl.coffee
@@ -1,4 +1,5 @@
 fhir = require('../fhir.js')
+instance = fhir()
 
 implementXhr = ($http)->
   (q)->
@@ -11,14 +12,14 @@ angular.module('ng-fhir', ['ng'])
 angular.module('ng-fhir').provider '$fhir', ()->
   prov = {}
   constructor = ($http)->
-    fhir.configure(baseUrl: prov.baseUrl)
-    fhir.setAdapter
+    instance.config.set(baseUrl: prov.baseUrl)
+    instance.adapter.set
       http: implementXhr($http)
 
-    search: fhir.search
-    conformance: fhir.conformance
-    profile: fhir.profile
-    transaction: fhir.transaction
+    search: instance.search
+    conformance: instance.conformance
+    profile: instance.profile
+    transaction: instance.transaction
 
   prov.$get = constructor
   prov

--- a/coffee/configuration.coffee
+++ b/coffee/configuration.coffee
@@ -1,4 +1,9 @@
-config = {}
-exports.config = config
-exports.configure = (m)->
-  config[k]=v for k,v of m
+class Configuration
+  constructor: (fhir)->
+    @config = {}
+    @fhir = fhir
+
+  set:  (m) => @config[k]=v for k,v of m
+  get:  ()  => @config
+
+module.exports = Configuration

--- a/coffee/conformance.coffee
+++ b/coffee/conformance.coffee
@@ -1,20 +1,22 @@
-adapter = require('./adapter.coffee')
-conf = require('./configuration.coffee')
-
-base = ()-> adapter.getAdapter()
+class Conformance
 
 # TODO: cache if configured
+  constructor: (fhir)->
+    @fhir = fhir
+    @conf = () -> @fhir.config.get()
 
-exports.conformance = (cb, err)->
-  base().http
-    method: 'GET'
-    url: "#{conf.config.baseUrl}/metadata"
-    success: cb
-    error: err
+  conformance: (cb, err)=>
+    @fhir.http.request
+      method: 'GET'
+      url: "#{@conf().baseUrl}/metadata"
+      success: cb
+      error: err
 
-exports.profile = (type, cb, err)->
-  base().http
-    method: 'GET'
-    url: "#{conf.config.baseUrl}/Profile/#{type}"
-    success: cb
-    error: err
+  profile: (type, cb, err)=>
+    @fhir.http.request
+      method: 'GET'
+      url: "#{@conf().baseUrl}/Profile/#{type}"
+      success: cb
+      error: err
+
+module.exports = Conformance

--- a/coffee/fhir.js
+++ b/coffee/fhir.js
@@ -1,20 +1,38 @@
 var adapter = require('./adapter.coffee');
 var cfg = require('./configuration.coffee');
-
+var http = require('./http.coffee');
 var search = require('./search.coffee');
 var conf = require('./conformance.coffee');
 var tran = require('./transaction.coffee');
 var tags = require('./tags.coffee');
 
-exports.setAdapter = adapter.setAdapter
-exports.configure = cfg.configure
-exports.config = cfg.config
+function fhir(){
 
-exports.search = search.search;
-exports.conformance = conf.conformance;
-exports.profile = conf.profile;
-exports.transaction = tran.transaction;
+  if (!(this instanceof arguments.callee)) {
+    return new arguments.callee();
+  }
+  
 
-exports.tags = tags.tags;
-exports.affixTags = tags.affixTags;
-exports.removeTags = tags.removeTags;
+  var _ = this._ = {
+    config: new cfg(this),
+    search: new search(this),
+    conformance: new conf(this),
+    transaction: new tran(this),
+    adapter: new adapter(this),
+    http: new http(this),
+    tags: tags
+  };
+
+  this.adapter = _.adapter;
+  this.config = _.config;
+  this.http = _.http;
+  this.conformance = _.conformance.conformance;
+  this.profile = _.conformance.profile;
+  this.search = _.search.search;
+  this.transaction = _.transaction.transaction;
+  this.tags = _.tags.tags;
+  this.affixTags = _.tags.affixTags;
+  this.removeTags = _.tags.removeTags;
+};
+module.exports = fhir;
+

--- a/coffee/http.coffee
+++ b/coffee/http.coffee
@@ -1,19 +1,22 @@
 adapter = require('./adapter.coffee')
-base = ()-> adapter.getAdapter()
 
-httpDecorators = [require('./authentication.coffee')]
+class Http
+  constructor: (fhir)->
+    @fhir = fhir
+    @httpDecorators = [require('./authentication.coffee')(fhir)]
+  search: (type, query, cb, err) ->
+ 
+  addDecorator: (d) ->
+    @removeDecorator(d)
+    @httpDecorators.push(d)
 
-dohttp =  (args) ->
-  base().http(
-    httpDecorators.reduce(
-      ((req, d) -> d(req)),
-      args))
+  removeDecorator: (d) ->
+    @httpDecorators = @httpDecorators.filter((dd)->(dd != d))
 
-dohttp.addDecorator = (d) ->
-  dohttp.removeDecorator(d)
-  httpDecorators.push(d)
+  request: (args) ->
+    @fhir.adapter.get().http(
+      @httpDecorators.reduce(
+        ((req, d) -> d(req)),
+        args))
 
-dohttp.removeDecorator = (d) ->
-  httpDecorators = httpDecorators.filter((dd)->(dd != d))
-
-module.exports = dohttp
+module.exports = Http

--- a/coffee/search.coffee
+++ b/coffee/search.coffee
@@ -1,34 +1,20 @@
-adapter = require('./adapter.coffee')
 queryBuider = require('./query.coffee')
-cfg = require('./configuration.coffee')
-http = require('./http.coffee')
 
-base = ()-> adapter.getAdapter()
+class Search
 
-# TODO: suport passing profile as type and query validation
+  constructor: (fhir)->
+    @fhir = fhir
 
-searchResource = (type, query, cb, err)->
-  queryStr = queryBuider.query(query)
-  uri = "#{cfg.config.baseUrl}/#{type}/_search?#{queryStr}"
-  http
-    method: 'GET',
-    url: uri,
-    success: (data)->
-      cb(data) if cb
-    error: (e)->
-      err(e) if err
+  search: (type, query, cb, err) =>
+    # TODO: suport passing profile as type and query validation
+    queryStr = queryBuider.query(query)
+    uri = "#{@fhir.config.get().baseUrl}/#{type}/_search?#{queryStr}"
+    @fhir.http.request
+      method: 'GET',
+      url: uri,
+      success: (data)->
+        cb(data) if cb
+      error: (e)->
+        err(e) if err
 
-# search(type, query, cb, err)
-# search resource
-#
-# * `type` - resource type string or profile object, if profile additional query validation will be done
-# * `query` - query object, see example and tests for syntax
-# * `cb` - callback function(bundle), bundle will be passed as first argument
-# * `err` - error callback function(error), this callback will be called if some error occurs
-#
-#
-# ```
-# search('Patient', {name: {$exact: 'maud'}}, cb, err)
-# ```
-#
-exports.search = searchResource
+module.exports = Search

--- a/coffee/tags.coffee
+++ b/coffee/tags.coffee
@@ -1,5 +1,3 @@
-adapter = require('./adapter.coffee')
-
 # READ OPERATIONS
 # =============================================================
 

--- a/coffee/transaction.coffee
+++ b/coffee/transaction.coffee
@@ -1,12 +1,16 @@
 adapter = require('./adapter.coffee')
-conf = require('./configuration.coffee')
 
-base = ()-> adapter.getAdapter()
+class Transaction
 
-exports.transaction = (bundle, cb, err)->
-  base().http
-    method: 'POST'
-    url: conf.config.baseUrl
-    data: bundle
-    success: cb
-    error: err
+  constructor: (fhir)->
+    @fhir = fhir
+
+  transaction: (bundle, cb, err)=>
+    @fhir.http.request
+      method: 'POST'
+      url: @fhir.config.get().baseUrl
+      data: bundle
+      success: cb
+      error: err
+
+module.exports = Transaction

--- a/dist/fhir.js
+++ b/dist/fhir.js
@@ -56,170 +56,268 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var adapter = __webpack_require__(1);
 	var cfg = __webpack_require__(2);
+	var http = __webpack_require__(3);
+	var search = __webpack_require__(4);
+	var conf = __webpack_require__(5);
+	var tran = __webpack_require__(6);
+	var tags = __webpack_require__(7);
 
-	var search = __webpack_require__(3);
-	var conf = __webpack_require__(4);
-	var tran = __webpack_require__(5);
-	var tags = __webpack_require__(6);
+	function fhir(){
 
-	exports.setAdapter = adapter.setAdapter
-	exports.configure = cfg.configure
-	exports.config = cfg.config
+	  if (!(this instanceof arguments.callee)) {
+	    return new arguments.callee();
+	  }
+	  
 
-	exports.search = search.search;
-	exports.conformance = conf.conformance;
-	exports.profile = conf.profile;
-	exports.transaction = tran.transaction;
+	  var _ = this._ = {
+	    config: new cfg(this),
+	    search: new search(this),
+	    conformance: new conf(this),
+	    transaction: new tran(this),
+	    adapter: new adapter(this),
+	    http: new http(this),
+	    tags: tags
+	  };
 
-	exports.tags = tags.tags;
-	exports.affixTags = tags.affixTags;
-	exports.removeTags = tags.removeTags;
+	  this.adapter = _.adapter;
+	  this.config = _.config;
+	  this.http = _.http;
+	  this.conformance = _.conformance.conformance;
+	  this.profile = _.conformance.profile;
+	  this.search = _.search.search;
+	  this.transaction = _.transaction.transaction;
+	  this.tags = _.tags.tags;
+	  this.affixTags = _.tags.affixTags;
+	  this.removeTags = _.tags.removeTags;
+	};
+	module.exports = fhir;
+
 
 
 /***/ },
 /* 1 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var adapter;
+	var Adapter;
 
-	adapter = null;
+	Adapter = (function() {
+	  function Adapter(fhir) {
+	    this.adapter = null;
+	    this.fhir = fhir;
+	  }
 
-	exports.setAdapter = function(x) {
-	  return adapter = x;
-	};
+	  Adapter.prototype.set = function(x) {
+	    return this.adapter = x;
+	  };
 
-	exports.getAdapter = function() {
-	  return adapter;
-	};
+	  Adapter.prototype.get = function() {
+	    return this.adapter;
+	  };
+
+	  return Adapter;
+
+	})();
+
+	module.exports = Adapter;
 
 
 /***/ },
 /* 2 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var config;
+	var Configuration,
+	  __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
 
-	config = {};
-
-	exports.config = config;
-
-	exports.configure = function(m) {
-	  var k, v, _results;
-	  _results = [];
-	  for (k in m) {
-	    v = m[k];
-	    _results.push(config[k] = v);
+	Configuration = (function() {
+	  function Configuration(fhir) {
+	    this.get = __bind(this.get, this);
+	    this.set = __bind(this.set, this);
+	    this.config = {};
+	    this.fhir = fhir;
 	  }
-	  return _results;
-	};
+
+	  Configuration.prototype.set = function(m) {
+	    var k, v, _results;
+	    _results = [];
+	    for (k in m) {
+	      v = m[k];
+	      _results.push(this.config[k] = v);
+	    }
+	    return _results;
+	  };
+
+	  Configuration.prototype.get = function() {
+	    return this.config;
+	  };
+
+	  return Configuration;
+
+	})();
+
+	module.exports = Configuration;
 
 
 /***/ },
 /* 3 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var adapter, base, cfg, http, queryBuider, searchResource;
+	var Http, adapter;
 
 	adapter = __webpack_require__(1);
 
-	queryBuider = __webpack_require__(7);
+	Http = (function() {
+	  function Http(fhir) {
+	    this.fhir = fhir;
+	    this.httpDecorators = [__webpack_require__(8)(fhir)];
+	  }
 
-	cfg = __webpack_require__(2);
+	  Http.prototype.search = function(type, query, cb, err) {};
 
-	http = __webpack_require__(8);
+	  Http.prototype.addDecorator = function(d) {
+	    this.removeDecorator(d);
+	    return this.httpDecorators.push(d);
+	  };
 
-	base = function() {
-	  return adapter.getAdapter();
-	};
+	  Http.prototype.removeDecorator = function(d) {
+	    return this.httpDecorators = this.httpDecorators.filter(function(dd) {
+	      return dd !== d;
+	    });
+	  };
 
-	searchResource = function(type, query, cb, err) {
-	  var queryStr, uri;
-	  queryStr = queryBuider.query(query);
-	  uri = "" + cfg.config.baseUrl + "/" + type + "/_search?" + queryStr;
-	  return http({
-	    method: 'GET',
-	    url: uri,
-	    success: function(data) {
-	      if (cb) {
-	        return cb(data);
-	      }
-	    },
-	    error: function(e) {
-	      if (err) {
-	        return err(e);
-	      }
-	    }
-	  });
-	};
+	  Http.prototype.request = function(args) {
+	    return this.fhir.adapter.get().http(this.httpDecorators.reduce((function(req, d) {
+	      return d(req);
+	    }), args));
+	  };
 
-	exports.search = searchResource;
+	  return Http;
+
+	})();
+
+	module.exports = Http;
 
 
 /***/ },
 /* 4 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var adapter, base, conf;
+	var Search, queryBuider,
+	  __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
 
-	adapter = __webpack_require__(1);
+	queryBuider = __webpack_require__(9);
 
-	conf = __webpack_require__(2);
+	Search = (function() {
+	  function Search(fhir) {
+	    this.search = __bind(this.search, this);
+	    this.fhir = fhir;
+	  }
 
-	base = function() {
-	  return adapter.getAdapter();
-	};
+	  Search.prototype.search = function(type, query, cb, err) {
+	    var queryStr, uri;
+	    queryStr = queryBuider.query(query);
+	    uri = "" + (this.fhir.config.get().baseUrl) + "/" + type + "/_search?" + queryStr;
+	    return this.fhir.http.request({
+	      method: 'GET',
+	      url: uri,
+	      success: function(data) {
+	        if (cb) {
+	          return cb(data);
+	        }
+	      },
+	      error: function(e) {
+	        if (err) {
+	          return err(e);
+	        }
+	      }
+	    });
+	  };
 
-	exports.conformance = function(cb, err) {
-	  return base().http({
-	    method: 'GET',
-	    url: "" + conf.config.baseUrl + "/metadata",
-	    success: cb,
-	    error: err
-	  });
-	};
+	  return Search;
 
-	exports.profile = function(type, cb, err) {
-	  return base().http({
-	    method: 'GET',
-	    url: "" + conf.config.baseUrl + "/Profile/" + type,
-	    success: cb,
-	    error: err
-	  });
-	};
+	})();
+
+	module.exports = Search;
 
 
 /***/ },
 /* 5 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var adapter, base, conf;
+	var Conformance,
+	  __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
 
-	adapter = __webpack_require__(1);
+	Conformance = (function() {
+	  function Conformance(fhir) {
+	    this.profile = __bind(this.profile, this);
+	    this.conformance = __bind(this.conformance, this);
+	    this.fhir = fhir;
+	    this.conf = function() {
+	      return this.fhir.config.get();
+	    };
+	  }
 
-	conf = __webpack_require__(2);
+	  Conformance.prototype.conformance = function(cb, err) {
+	    return this.fhir.http.request({
+	      method: 'GET',
+	      url: "" + (this.conf().baseUrl) + "/metadata",
+	      success: cb,
+	      error: err
+	    });
+	  };
 
-	base = function() {
-	  return adapter.getAdapter();
-	};
+	  Conformance.prototype.profile = function(type, cb, err) {
+	    return this.fhir.http.request({
+	      method: 'GET',
+	      url: "" + (this.conf().baseUrl) + "/Profile/" + type,
+	      success: cb,
+	      error: err
+	    });
+	  };
 
-	exports.transaction = function(bundle, cb, err) {
-	  return base().http({
-	    method: 'POST',
-	    url: conf.config.baseUrl,
-	    data: bundle,
-	    success: cb,
-	    error: err
-	  });
-	};
+	  return Conformance;
+
+	})();
+
+	module.exports = Conformance;
 
 
 /***/ },
 /* 6 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var adapter, affixTags, affixTagsToResource, affixTagsToResourceVersion, removeTags, removeTagsFromResource, removeTagsFromResourceVerson, tags, tagsAll, tagsResource, tagsResourceType, tagsResourceVersion;
+	var Transaction, adapter,
+	  __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
 
 	adapter = __webpack_require__(1);
+
+	Transaction = (function() {
+	  function Transaction(fhir) {
+	    this.transaction = __bind(this.transaction, this);
+	    this.fhir = fhir;
+	  }
+
+	  Transaction.prototype.transaction = function(bundle, cb, err) {
+	    return this.fhir.http.request({
+	      method: 'POST',
+	      url: this.fhir.config.get().baseUrl,
+	      data: bundle,
+	      success: cb,
+	      error: err
+	    });
+	  };
+
+	  return Transaction;
+
+	})();
+
+	module.exports = Transaction;
+
+
+/***/ },
+/* 7 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var affixTags, affixTagsToResource, affixTagsToResourceVersion, removeTags, removeTagsFromResource, removeTagsFromResourceVerson, tags, tagsAll, tagsResource, tagsResourceType, tagsResourceVersion;
 
 	tagsAll = function() {
 	  return console.log('impl me');
@@ -298,7 +396,63 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 7 */
+/* 8 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var basic, bearer, btoa, identity, merge, withAuth;
+
+	btoa = __webpack_require__(10).btoa;
+
+	merge = __webpack_require__(11);
+
+	bearer = function(cfg) {
+	  return function(req) {
+	    return withAuth(req, "Bearer " + cfg.auth.bearer);
+	  };
+	};
+
+	basic = function(cfg) {
+	  return function(req) {
+	    return withAuth(req, "Basic " + btoa("" + cfg.auth.user + ":" + cfg.auth.pass));
+	  };
+	};
+
+	identity = function(req) {
+	  return req;
+	};
+
+	withAuth = function(req, a) {
+	  var headers;
+	  headers = merge(true, req.headers || {}, {
+	    "Authorization": a
+	  });
+	  return merge(true, req, {
+	    headers: headers
+	  });
+	};
+
+	module.exports = function(fhir) {
+	  return function(req) {
+	    var auth, cfg;
+	    cfg = fhir.config.get();
+	    auth = (function() {
+	      var _ref, _ref1, _ref2;
+	      switch (false) {
+	        case !(cfg != null ? (_ref = cfg.auth) != null ? _ref.bearer : void 0 : void 0):
+	          return bearer(cfg);
+	        case !((cfg != null ? (_ref1 = cfg.auth) != null ? _ref1.user : void 0 : void 0) && (cfg != null ? (_ref2 = cfg.auth) != null ? _ref2.pass : void 0 : void 0)):
+	          return basic(cfg);
+	        default:
+	          return identity;
+	      }
+	    })();
+	    return auth(req);
+	  };
+	};
+
+
+/***/ },
+/* 9 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var MODIFIERS, OPERATORS, assertArray, assertObject, buildSearchParams, expandParam, handleInclude, handleSort, identity, isOperator, linearizeOne, linearizeParams, reduceMap, type;
@@ -500,99 +654,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports._query = linearizeParams;
 
 	exports.query = buildSearchParams;
-
-
-/***/ },
-/* 8 */
-/***/ function(module, exports, __webpack_require__) {
-
-	var adapter, base, dohttp, httpDecorators;
-
-	adapter = __webpack_require__(1);
-
-	base = function() {
-	  return adapter.getAdapter();
-	};
-
-	httpDecorators = [__webpack_require__(9)];
-
-	dohttp = function(args) {
-	  return base().http(httpDecorators.reduce((function(req, d) {
-	    return d(req);
-	  }), args));
-	};
-
-	dohttp.addDecorator = function(d) {
-	  dohttp.removeDecorator(d);
-	  return httpDecorators.push(d);
-	};
-
-	dohttp.removeDecorator = function(d) {
-	  return httpDecorators = httpDecorators.filter(function(dd) {
-	    return dd !== d;
-	  });
-	};
-
-	module.exports = dohttp;
-
-
-/***/ },
-/* 9 */
-/***/ function(module, exports, __webpack_require__) {
-
-	var adapter, base, basic, bearer, btoa, cfg, identity, merge, withAuth;
-
-	cfg = __webpack_require__(2).config;
-
-	adapter = __webpack_require__(1);
-
-	btoa = __webpack_require__(10).btoa;
-
-	merge = __webpack_require__(11);
-
-	base = function() {
-	  return adapter.getAdapter();
-	};
-
-	bearer = function(req) {
-	  return withAuth(req, "Bearer " + cfg.auth.bearer);
-	};
-
-	basic = function(req) {
-	  console.log("do req with auth", req, btoa("" + cfg.auth.user + ":" + cfg.auth.pass));
-	  return withAuth(req, "Basic " + btoa("" + cfg.auth.user + ":" + cfg.auth.pass));
-	};
-
-	identity = function(req) {
-	  return req;
-	};
-
-	withAuth = function(req, a) {
-	  var headers;
-	  headers = merge(true, req.headers || {}, {
-	    "Authorization": a
-	  });
-	  return merge(true, req, {
-	    headers: headers
-	  });
-	};
-
-	module.exports = function(req) {
-	  var auth;
-	  auth = (function() {
-	    var _ref, _ref1, _ref2;
-	    switch (false) {
-	      case !(cfg != null ? (_ref = cfg.auth) != null ? _ref.bearer : void 0 : void 0):
-	        return bearer;
-	      case !((cfg != null ? (_ref1 = cfg.auth) != null ? _ref1.user : void 0 : void 0) && (cfg != null ? (_ref2 = cfg.auth) != null ? _ref2.pass : void 0 : void 0)):
-	        return basic;
-	      default:
-	        return identity;
-	    }
-	  })();
-	  console.log("woth auth fn", req, auth);
-	  return auth(req);
-	};
 
 
 /***/ },

--- a/dist/jqFhir.js
+++ b/dist/jqFhir.js
@@ -61,16 +61,17 @@ return /******/ (function(modules) { // webpackBootstrap
 /* 1 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var $, adapter, fhir;
+	var $, adapter, fhir, instance;
 
 	fhir = __webpack_require__(3);
 
 	$ = __webpack_require__(2);
 
+	instance = fhir();
+
 	adapter = {
 	  "http": function(q) {
 	    var a;
-	    console.log("Requesting", q.method, q.url, q.headers);
 	    a = $.ajax({
 	      type: q.method,
 	      url: q.url,
@@ -85,16 +86,16 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }
 	};
 
-	fhir.setAdapter(adapter);
+	instance.adapter.set(adapter);
 
-	exports.fhir = fhir;
+	exports.fhir = instance;
 
-	exports.configure = fhir.configure;
+	exports.config = instance.config;
 
 	exports.search = function(type, query) {
 	  var ret;
 	  ret = $.Deferred();
-	  fhir.search(type, query, ret.resolve, ret.reject);
+	  instance.search(type, query, ret.resolve, ret.reject);
 	  return ret;
 	};
 
@@ -111,170 +112,268 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var adapter = __webpack_require__(4);
 	var cfg = __webpack_require__(5);
+	var http = __webpack_require__(6);
+	var search = __webpack_require__(7);
+	var conf = __webpack_require__(8);
+	var tran = __webpack_require__(9);
+	var tags = __webpack_require__(10);
 
-	var search = __webpack_require__(6);
-	var conf = __webpack_require__(7);
-	var tran = __webpack_require__(8);
-	var tags = __webpack_require__(9);
+	function fhir(){
 
-	exports.setAdapter = adapter.setAdapter
-	exports.configure = cfg.configure
-	exports.config = cfg.config
+	  if (!(this instanceof arguments.callee)) {
+	    return new arguments.callee();
+	  }
+	  
 
-	exports.search = search.search;
-	exports.conformance = conf.conformance;
-	exports.profile = conf.profile;
-	exports.transaction = tran.transaction;
+	  var _ = this._ = {
+	    config: new cfg(this),
+	    search: new search(this),
+	    conformance: new conf(this),
+	    transaction: new tran(this),
+	    adapter: new adapter(this),
+	    http: new http(this),
+	    tags: tags
+	  };
 
-	exports.tags = tags.tags;
-	exports.affixTags = tags.affixTags;
-	exports.removeTags = tags.removeTags;
+	  this.adapter = _.adapter;
+	  this.config = _.config;
+	  this.http = _.http;
+	  this.conformance = _.conformance.conformance;
+	  this.profile = _.conformance.profile;
+	  this.search = _.search.search;
+	  this.transaction = _.transaction.transaction;
+	  this.tags = _.tags.tags;
+	  this.affixTags = _.tags.affixTags;
+	  this.removeTags = _.tags.removeTags;
+	};
+	module.exports = fhir;
+
 
 
 /***/ },
 /* 4 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var adapter;
+	var Adapter;
 
-	adapter = null;
+	Adapter = (function() {
+	  function Adapter(fhir) {
+	    this.adapter = null;
+	    this.fhir = fhir;
+	  }
 
-	exports.setAdapter = function(x) {
-	  return adapter = x;
-	};
+	  Adapter.prototype.set = function(x) {
+	    return this.adapter = x;
+	  };
 
-	exports.getAdapter = function() {
-	  return adapter;
-	};
+	  Adapter.prototype.get = function() {
+	    return this.adapter;
+	  };
+
+	  return Adapter;
+
+	})();
+
+	module.exports = Adapter;
 
 
 /***/ },
 /* 5 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var config;
+	var Configuration,
+	  __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
 
-	config = {};
-
-	exports.config = config;
-
-	exports.configure = function(m) {
-	  var k, v, _results;
-	  _results = [];
-	  for (k in m) {
-	    v = m[k];
-	    _results.push(config[k] = v);
+	Configuration = (function() {
+	  function Configuration(fhir) {
+	    this.get = __bind(this.get, this);
+	    this.set = __bind(this.set, this);
+	    this.config = {};
+	    this.fhir = fhir;
 	  }
-	  return _results;
-	};
+
+	  Configuration.prototype.set = function(m) {
+	    var k, v, _results;
+	    _results = [];
+	    for (k in m) {
+	      v = m[k];
+	      _results.push(this.config[k] = v);
+	    }
+	    return _results;
+	  };
+
+	  Configuration.prototype.get = function() {
+	    return this.config;
+	  };
+
+	  return Configuration;
+
+	})();
+
+	module.exports = Configuration;
 
 
 /***/ },
 /* 6 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var adapter, base, cfg, http, queryBuider, searchResource;
+	var Http, adapter;
 
 	adapter = __webpack_require__(4);
 
-	queryBuider = __webpack_require__(10);
+	Http = (function() {
+	  function Http(fhir) {
+	    this.fhir = fhir;
+	    this.httpDecorators = [__webpack_require__(11)(fhir)];
+	  }
 
-	cfg = __webpack_require__(5);
+	  Http.prototype.search = function(type, query, cb, err) {};
 
-	http = __webpack_require__(11);
+	  Http.prototype.addDecorator = function(d) {
+	    this.removeDecorator(d);
+	    return this.httpDecorators.push(d);
+	  };
 
-	base = function() {
-	  return adapter.getAdapter();
-	};
+	  Http.prototype.removeDecorator = function(d) {
+	    return this.httpDecorators = this.httpDecorators.filter(function(dd) {
+	      return dd !== d;
+	    });
+	  };
 
-	searchResource = function(type, query, cb, err) {
-	  var queryStr, uri;
-	  queryStr = queryBuider.query(query);
-	  uri = "" + cfg.config.baseUrl + "/" + type + "/_search?" + queryStr;
-	  return http({
-	    method: 'GET',
-	    url: uri,
-	    success: function(data) {
-	      if (cb) {
-	        return cb(data);
-	      }
-	    },
-	    error: function(e) {
-	      if (err) {
-	        return err(e);
-	      }
-	    }
-	  });
-	};
+	  Http.prototype.request = function(args) {
+	    return this.fhir.adapter.get().http(this.httpDecorators.reduce((function(req, d) {
+	      return d(req);
+	    }), args));
+	  };
 
-	exports.search = searchResource;
+	  return Http;
+
+	})();
+
+	module.exports = Http;
 
 
 /***/ },
 /* 7 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var adapter, base, conf;
+	var Search, queryBuider,
+	  __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
 
-	adapter = __webpack_require__(4);
+	queryBuider = __webpack_require__(12);
 
-	conf = __webpack_require__(5);
+	Search = (function() {
+	  function Search(fhir) {
+	    this.search = __bind(this.search, this);
+	    this.fhir = fhir;
+	  }
 
-	base = function() {
-	  return adapter.getAdapter();
-	};
+	  Search.prototype.search = function(type, query, cb, err) {
+	    var queryStr, uri;
+	    queryStr = queryBuider.query(query);
+	    uri = "" + (this.fhir.config.get().baseUrl) + "/" + type + "/_search?" + queryStr;
+	    return this.fhir.http.request({
+	      method: 'GET',
+	      url: uri,
+	      success: function(data) {
+	        if (cb) {
+	          return cb(data);
+	        }
+	      },
+	      error: function(e) {
+	        if (err) {
+	          return err(e);
+	        }
+	      }
+	    });
+	  };
 
-	exports.conformance = function(cb, err) {
-	  return base().http({
-	    method: 'GET',
-	    url: "" + conf.config.baseUrl + "/metadata",
-	    success: cb,
-	    error: err
-	  });
-	};
+	  return Search;
 
-	exports.profile = function(type, cb, err) {
-	  return base().http({
-	    method: 'GET',
-	    url: "" + conf.config.baseUrl + "/Profile/" + type,
-	    success: cb,
-	    error: err
-	  });
-	};
+	})();
+
+	module.exports = Search;
 
 
 /***/ },
 /* 8 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var adapter, base, conf;
+	var Conformance,
+	  __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
 
-	adapter = __webpack_require__(4);
+	Conformance = (function() {
+	  function Conformance(fhir) {
+	    this.profile = __bind(this.profile, this);
+	    this.conformance = __bind(this.conformance, this);
+	    this.fhir = fhir;
+	    this.conf = function() {
+	      return this.fhir.config.get();
+	    };
+	  }
 
-	conf = __webpack_require__(5);
+	  Conformance.prototype.conformance = function(cb, err) {
+	    return this.fhir.http.request({
+	      method: 'GET',
+	      url: "" + (this.conf().baseUrl) + "/metadata",
+	      success: cb,
+	      error: err
+	    });
+	  };
 
-	base = function() {
-	  return adapter.getAdapter();
-	};
+	  Conformance.prototype.profile = function(type, cb, err) {
+	    return this.fhir.http.request({
+	      method: 'GET',
+	      url: "" + (this.conf().baseUrl) + "/Profile/" + type,
+	      success: cb,
+	      error: err
+	    });
+	  };
 
-	exports.transaction = function(bundle, cb, err) {
-	  return base().http({
-	    method: 'POST',
-	    url: conf.config.baseUrl,
-	    data: bundle,
-	    success: cb,
-	    error: err
-	  });
-	};
+	  return Conformance;
+
+	})();
+
+	module.exports = Conformance;
 
 
 /***/ },
 /* 9 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var adapter, affixTags, affixTagsToResource, affixTagsToResourceVersion, removeTags, removeTagsFromResource, removeTagsFromResourceVerson, tags, tagsAll, tagsResource, tagsResourceType, tagsResourceVersion;
+	var Transaction, adapter,
+	  __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
 
 	adapter = __webpack_require__(4);
+
+	Transaction = (function() {
+	  function Transaction(fhir) {
+	    this.transaction = __bind(this.transaction, this);
+	    this.fhir = fhir;
+	  }
+
+	  Transaction.prototype.transaction = function(bundle, cb, err) {
+	    return this.fhir.http.request({
+	      method: 'POST',
+	      url: this.fhir.config.get().baseUrl,
+	      data: bundle,
+	      success: cb,
+	      error: err
+	    });
+	  };
+
+	  return Transaction;
+
+	})();
+
+	module.exports = Transaction;
+
+
+/***/ },
+/* 10 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var affixTags, affixTagsToResource, affixTagsToResourceVersion, removeTags, removeTagsFromResource, removeTagsFromResourceVerson, tags, tagsAll, tagsResource, tagsResourceType, tagsResourceVersion;
 
 	tagsAll = function() {
 	  return console.log('impl me');
@@ -353,7 +452,63 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 10 */
+/* 11 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var basic, bearer, btoa, identity, merge, withAuth;
+
+	btoa = __webpack_require__(13).btoa;
+
+	merge = __webpack_require__(14);
+
+	bearer = function(cfg) {
+	  return function(req) {
+	    return withAuth(req, "Bearer " + cfg.auth.bearer);
+	  };
+	};
+
+	basic = function(cfg) {
+	  return function(req) {
+	    return withAuth(req, "Basic " + btoa("" + cfg.auth.user + ":" + cfg.auth.pass));
+	  };
+	};
+
+	identity = function(req) {
+	  return req;
+	};
+
+	withAuth = function(req, a) {
+	  var headers;
+	  headers = merge(true, req.headers || {}, {
+	    "Authorization": a
+	  });
+	  return merge(true, req, {
+	    headers: headers
+	  });
+	};
+
+	module.exports = function(fhir) {
+	  return function(req) {
+	    var auth, cfg;
+	    cfg = fhir.config.get();
+	    auth = (function() {
+	      var _ref, _ref1, _ref2;
+	      switch (false) {
+	        case !(cfg != null ? (_ref = cfg.auth) != null ? _ref.bearer : void 0 : void 0):
+	          return bearer(cfg);
+	        case !((cfg != null ? (_ref1 = cfg.auth) != null ? _ref1.user : void 0 : void 0) && (cfg != null ? (_ref2 = cfg.auth) != null ? _ref2.pass : void 0 : void 0)):
+	          return basic(cfg);
+	        default:
+	          return identity;
+	      }
+	    })();
+	    return auth(req);
+	  };
+	};
+
+
+/***/ },
+/* 12 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var MODIFIERS, OPERATORS, assertArray, assertObject, buildSearchParams, expandParam, handleInclude, handleSort, identity, isOperator, linearizeOne, linearizeParams, reduceMap, type;
@@ -555,99 +710,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports._query = linearizeParams;
 
 	exports.query = buildSearchParams;
-
-
-/***/ },
-/* 11 */
-/***/ function(module, exports, __webpack_require__) {
-
-	var adapter, base, dohttp, httpDecorators;
-
-	adapter = __webpack_require__(4);
-
-	base = function() {
-	  return adapter.getAdapter();
-	};
-
-	httpDecorators = [__webpack_require__(12)];
-
-	dohttp = function(args) {
-	  return base().http(httpDecorators.reduce((function(req, d) {
-	    return d(req);
-	  }), args));
-	};
-
-	dohttp.addDecorator = function(d) {
-	  dohttp.removeDecorator(d);
-	  return httpDecorators.push(d);
-	};
-
-	dohttp.removeDecorator = function(d) {
-	  return httpDecorators = httpDecorators.filter(function(dd) {
-	    return dd !== d;
-	  });
-	};
-
-	module.exports = dohttp;
-
-
-/***/ },
-/* 12 */
-/***/ function(module, exports, __webpack_require__) {
-
-	var adapter, base, basic, bearer, btoa, cfg, identity, merge, withAuth;
-
-	cfg = __webpack_require__(5).config;
-
-	adapter = __webpack_require__(4);
-
-	btoa = __webpack_require__(13).btoa;
-
-	merge = __webpack_require__(14);
-
-	base = function() {
-	  return adapter.getAdapter();
-	};
-
-	bearer = function(req) {
-	  return withAuth(req, "Bearer " + cfg.auth.bearer);
-	};
-
-	basic = function(req) {
-	  console.log("do req with auth", req, btoa("" + cfg.auth.user + ":" + cfg.auth.pass));
-	  return withAuth(req, "Basic " + btoa("" + cfg.auth.user + ":" + cfg.auth.pass));
-	};
-
-	identity = function(req) {
-	  return req;
-	};
-
-	withAuth = function(req, a) {
-	  var headers;
-	  headers = merge(true, req.headers || {}, {
-	    "Authorization": a
-	  });
-	  return merge(true, req, {
-	    headers: headers
-	  });
-	};
-
-	module.exports = function(req) {
-	  var auth;
-	  auth = (function() {
-	    var _ref, _ref1, _ref2;
-	    switch (false) {
-	      case !(cfg != null ? (_ref = cfg.auth) != null ? _ref.bearer : void 0 : void 0):
-	        return bearer;
-	      case !((cfg != null ? (_ref1 = cfg.auth) != null ? _ref1.user : void 0 : void 0) && (cfg != null ? (_ref2 = cfg.auth) != null ? _ref2.pass : void 0 : void 0)):
-	        return basic;
-	      default:
-	        return identity;
-	    }
-	  })();
-	  console.log("woth auth fn", req, auth);
-	  return auth(req);
-	};
 
 
 /***/ },

--- a/integration_test/jquerySpec.coffee
+++ b/integration_test/jquerySpec.coffee
@@ -5,8 +5,8 @@ fhir = jqFhir
 describe "jqFhir", ->
 
   it "simplest", (done) ->
-    fhir.configure(baseUrl: 'https://ci-api.fhir.me')
-    fhir.configure(auth: {user: 'client', pass: 'secret'})
+    fhir.config.set(baseUrl: 'https://ci-api.fhir.me')
+    fhir.config.set(auth: {user: 'client', pass: 'secret'})
     fhir.search('Patient', {name: 'maud'})
     .then (d)->
        done()

--- a/test/authentiationSpec.coffee
+++ b/test/authentiationSpec.coffee
@@ -1,17 +1,20 @@
-authentication = require('../coffee/authentication.coffee')
-conf = require('../coffee/configuration.coffee')
+fhir = require('../coffee/fhir.js')
+instance = new fhir()
+
+auth = require('../coffee/authentication.coffee')
+conf = instance.config
 
 describe "authentication:", ->
-  subject = authentication
+  subject = auth(instance)
 
   it "no auth", ->
-    conf.configure {auth: null}
+    conf.set auth: null
     authed = subject({a:1, b:2})
-    expect(authed?.headers?.Authorization).toBeUndefined();
+    expect(authed?.headers?.Authorization).toBeUndefined()
 
 
   it "bearer", ->
-    conf.configure
+    conf.set
       auth: {
         bearer: "test-token"
       }
@@ -19,7 +22,7 @@ describe "authentication:", ->
     expect(authed.headers.Authorization).toBe("Bearer test-token")
 
   it "basic", ->
-    conf.configure
+    conf.set
       auth: {
         user: "test",
         pass: "123"

--- a/test/conformanceSpec.coffee
+++ b/test/conformanceSpec.coffee
@@ -1,26 +1,29 @@
-f = require('../coffee/conformance.coffee')
-a = require('../coffee/adapter.coffee')
-conf = require('../coffee/configuration.coffee')
+fhir = require('../coffee/fhir.js')
 
-conf.configure
+instance = new fhir()
+f = instance._.conformance
+a = instance._.adapter
+
+instance.config.set
   baseUrl: 'BASE'
 
 nop = (x)-> x
 
 describe 'conformance', ->
   it 'success', (done)->
-    a.setAdapter
-      http: (q)->
-        expect(q.method).toBe('GET')
-        expect(q.url).toBe('BASE/metadata')
-        q.success('ok')
+    console.log "gonna set an adapter", a.get()
+
+    a.set http: (q)->
+      expect(q.method).toBe('GET')
+      expect(q.url).toBe('BASE/metadata')
+      q.success('ok')
 
     f.conformance (data)->
       expect(data).toBe('ok')
       done()
 
   it 'error', (done)->
-    a.setAdapter
+    a.set
       http: (q)->
         q.error('ok')
 
@@ -31,7 +34,7 @@ describe 'conformance', ->
 describe 'profile', ->
 
   it 'success', (done)->
-    a.setAdapter
+    a.set
       http: (q)->
         expect(q.method).toBe('GET')
         expect(q.url).toBe('BASE/Profile/Alert')
@@ -41,7 +44,7 @@ describe 'profile', ->
       expect(data).toBe('ok')
       done()
   it 'error', (done)->
-    a.setAdapter
+    a.set
       http: (q)->
         q.error('ok')
 

--- a/test/searchSpec.coffee
+++ b/test/searchSpec.coffee
@@ -1,20 +1,22 @@
-a = require('../coffee/adapter.coffee')
-conf = require('../coffee/configuration.coffee')
-mod = require('../coffee/search.coffee')
+fhir = require('../coffee/fhir.js')
+instance = new fhir()
+conf = instance.config
 
-conf.configure
+a = instance._.adapter
+
+conf.set
   baseUrl: 'BASE'
 
 nop = ()->
 
 describe "search:", ->
-  subject = mod
+  subject = instance._.search
 
   it "api", ->
     expect(subject.search).not.toBe(null)
 
   it "search success", (done)->
-    a.setAdapter
+    a.set
       http: (q)->
         expect(q.method).toBe('GET')
         expect(q.url).toBe('BASE/Patient/_search?name=maud')
@@ -28,7 +30,7 @@ describe "search:", ->
       expect(e).toBe('error')
       done()
 
-    a.setAdapter
+    a.set
       http: (q)-> q.error('error')
 
     subject.search('Patient', {name: 'maud'}, nop, err)

--- a/test/transactionSpec.coffee
+++ b/test/transactionSpec.coffee
@@ -1,8 +1,11 @@
-f = require('../coffee/transaction.coffee')
-a = require('../coffee/adapter.coffee')
-conf = require('../coffee/configuration.coffee')
+fhir = require('../coffee/fhir.js')
+instance = new fhir()
 
-conf.configure
+f = instance._.transaction
+a = instance._.adapter
+conf = instance.config
+
+conf.set
   baseUrl: 'BASE'
 
 nop = (x)-> x
@@ -10,7 +13,7 @@ bundle = 'bundle'
 
 describe 'transaction', ->
   it 'success', (done)->
-    a.setAdapter
+    a.set
       http: (q)->
         expect(q.method).toBe('POST')
         expect(q.url).toBe('BASE')
@@ -22,7 +25,7 @@ describe 'transaction', ->
       done()
 
   it 'error', (done)->
-    a.setAdapter
+    a.set
       http: (q)->
         q.error('ok')
 


### PR DESCRIPTION
This is one take on how to allow multiple instances of a client (that don't share fixed global state like the config). Currently the unit tests are relying on more behavior than just their specific module; we'd need more mocks to simulate the way that a client is passed to the various classes (Adapter, Config, etc) on initialization.

You may have a better idea about how to accomplish this same effect -- if so, feel free to suggest an alternative!
