### PR TITLE
Move 'credientials: include' option from fetch adapter to middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ JavaScript client for FHIR
  - Support FHIR CRUD operations
  - Friendly and expressive query syntax
  - Support for adapters that provide idiomatic interfaces in angular, jQuery, extjs, etc
- - Support for access control (HTTP basic, OAuth2)
+ - Support for access control (HTTP basic, OAuth2, Cookies)
  - ...
 
 ## Development
@@ -63,7 +63,9 @@ var config = {
      // OR for basic auth
      user: 'user',
      pass: 'secret'
-  }
+  },
+  // Valid Options are 'same-origin', 'include'
+  credentials: 'same-origin'
 }
 
 myClient = fhir(config, adapter)
@@ -92,6 +94,24 @@ When you provide both user name and password, basic auth will be used.
 This is your basic auth password.
 
 When you provide both user name and password, basic auth will be used.
+
+##### credentials
+This option controls the behaviour of sending cookies to the remote server. Refer to the table below for how to configure the option for your desired adapter.
+
+| Adapter  | credentials   | Result                    |
+|----------|---------------|---------------------------|
+| Native   | 'same-origin' | Cookies are sent to the server, if it is on the same host as the origin sender |
+| Native   | 'include'     | Send cookies to all hosts |
+| jQuery   | 'same-origin' | ignored                   |
+| jQuery   | 'include'     | Send cookies to all hosts |
+| yui      | 'same-origin' | ignored                   |
+| yui      | 'include'     | Send cookies to all hosts |
+| angular  | 'same-origin' | ignored                   |
+| angular  | 'include'     | ignored                   |
+| node     | 'same-origin' | ignored                   |
+| node     | 'include'     | ignored                   |
+
+
 ### Adapter implementation
 
 Currently each adapter must implement an

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ configuration object & adapter object.  Adapters are
 implemented for concrete frameworks/libs (see below).
 
 ```
-var cfg = {
+var config = {
   // FHIR server base url
   baseUrl: 'http://myfhirserver.com',
   auth: {
@@ -66,9 +66,32 @@ var cfg = {
   }
 }
 
-myClient = fhir(cfg, adapter)
+myClient = fhir(config, adapter)
 ```
 
+#### Config Object
+The config object is an object that is passed through the middleware chain. Any values in the config object that are not mutated by middleware will be available to the adapter.
+
+Because middleware mutates the config, it is strongly recommended when implementing an adapter to not directly rely on config passed in.
+
+##### baseUrl
+This is the full url to your FHIR server. Resources will be appended to the end of it.
+
+##### auth
+This is an object representing your authentication requirements. Possible options include:
+
+###### bearer
+This is your Bearer token when provided, it will add an `Authorization: Bearer <token>` header to your requests.
+
+###### user
+This is your Basic auth Username.
+
+When you provide both user name and password, basic auth will be used.
+
+###### pass
+This is your basic auth password.
+
+When you provide both user name and password, basic auth will be used.
 ### Adapter implementation
 
 Currently each adapter must implement an

--- a/src/adapters/jquery.js
+++ b/src/adapters/jquery.js
@@ -17,7 +17,8 @@
                 headers: args.headers,
                 dataType: "json",
                 contentType: "application/json",
-                data: args.data || args.params
+                data: args.data || args.params,
+                withCredentials: args.credentials === 'include',
             };
             jquery.ajax(opts)
                 .done(function(data, status, xhr) {ret.resolve({data: data, status: status, headers: xhr.getResponseHeader, config: args});})

--- a/src/adapters/native.js
+++ b/src/adapters/native.js
@@ -42,7 +42,7 @@ var adapter = {
     var fetchOptions = args;
 
     // Pass along cookies
-    fetchOptions.credentials = 'include';
+    fetchOptions.credentials = args.credentials || '';
 
     // data neeeds to map to body
     fetchOptions.body = fetchOptions.data;

--- a/src/adapters/yui.js
+++ b/src/adapters/yui.js
@@ -29,6 +29,10 @@
                     deff.reject(null, args);
                 }
             };
+            args.xdr = {
+              use: "native",
+              credentials: args.credentials === 'include'
+            };
             io(args.url, args);
             return deff.promise;
         }

--- a/src/fhir.js
+++ b/src/fhir.js
@@ -27,6 +27,7 @@
                 .and($Errors)
                 .and(auth.$Basic)
                 .and(auth.$Bearer)
+                .and(auth.$Credentials)
                 .and(transport.$JsonData)
                 .and($$Header('Accept', 'application/json'))
                 .and($$Header('Content-Type', 'application/json'));

--- a/src/middlewares/auth.js
+++ b/src/middlewares/auth.js
@@ -15,4 +15,21 @@
         }
     });
 
+    var credentials;
+    // this first middleware sets the credentials attribute to empty, so
+    // adapters cannot use it directly, thus enforcing a valid value to be parsed in.
+    exports.$Credentials = mw.Middleware(mw.$$Attr('credentials', function(args){
+      // Assign value for later checking
+      credentials = args.credentials
+
+      // Needs to return non-null and not-undefined
+      // in order for value to be (un)set
+      return '';
+    })).and(mw.$$Attr('credentials', function(args){
+        // check credentials for valid options, valid for fetch
+        if(['same-origin', 'include'].indexOf(credentials) > -1 ){
+            return credentials;
+        }
+    }));
+
 }).call(this);

--- a/test/authSpec.coffee
+++ b/test/authSpec.coffee
@@ -21,3 +21,36 @@ describe "authentication", ->
     authed = http(a:1, b:2, auth: { user: "test", pass: "123" })
 
     assert.deepEqual(authed.headers.Authorization, "Basic dGVzdDoxMjM=")
+
+  describe "credentials", ->
+    beforeEach ->
+      @http = auth.$Credentials identity
+
+    afterEach ->
+      delete @http
+
+    it "same-origin", ->
+      authed = @http a:1, b:2, credentials: "same-origin"
+      assert.equal authed.credentials, "same-origin"
+
+
+    it "include", ->
+      authed = @http a:1, b:2, credentials: "include"
+      assert.equal authed.credentials, "include"
+
+
+    it "invalid", ->
+      authed = @http a:1, b:2, credentials: "invalid"
+      assert.equal authed.credentials, ""
+
+    it "empty string", ->
+      authed = @http a:1, b:2, credentials: ""
+      assert.equal authed.credentials, ""
+
+    it "true", ->
+      authed = @http a:1, b:2, credentials: true
+      assert.equal authed.credentials, ""
+
+    it "false", ->
+      authed = @http a:1, b:2, credentials: false
+      assert.equal authed.credentials, ""


### PR DESCRIPTION
Hey Guys and Gals, 
I've had a crack at moving the 'credentials' flag into auth middleware. A couple of things that I noticed are 

* Originally, I used `credientials` as the config option. However, I found that when I tried to set an attribute for `withCredientials` my adapter still had access to `credentials` which I didn't want. (I want the adapter to consume the result of the middleware, not the original config value) I have tried to rectify this issue with a fancy middleware chain that nullifies the original value - I'm not very happy with how it turned out - as it seems very complicated for a simple task
* I've update YUI, jQuery and native adapters to consume the new credientials flags. 

I'm opening the PR to get feedback so far. There is still work to do. 

In particular - I think that further tests are required around the adapters, to ensure that they correctly implement the flag. 