### PR TITLE
Added agentOptions to config

### DIFF
--- a/src/middlewares/config.js
+++ b/src/middlewares/config.js
@@ -15,6 +15,7 @@
                 copyAttr(cfg, args, 'debug');
                 copyAttr(cfg, args, 'credentials');
                 copyAttr(cfg, args, 'headers');
+                copyAttr(cfg, args, 'agentOptions');
                 copyAttr(adapter, args, 'defer');
                 copyAttr(adapter, args, 'http');
                 return h(args);


### PR DESCRIPTION
request object will use agentOptions to pass things like certs.