### PR TITLE
Native adapter added to the webpack.config to be built on 'npm run-script build'

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,8 @@ module.exports = {
     fhir: ["./src/fhir.js"],
     ngFhir: "./src/adapters/angularjs.js",
     jqFhir: "./src/adapters/jquery.js",
-    yuifhir: "./src/adapters/yui.js"
+    yuifhir: "./src/adapters/yui.js",
+    nativeFhir: "./src/adapters/native.js"
   },
   node: {
     buffer: "mock"


### PR DESCRIPTION
`adapters/native.js` added to `webpack.config.js` file. Now, it creates a build for 'native.js' adaper on `dist/nativeFhir.js` when running `npm run-script build`. This file can be imported as:

```
    <script src="js/nativeFhir.js"></script>
```

And used in other scripts like:

```
var config = {"baseUrl":"http://base.url", ... };

var client = fhir(config);

client.read({type: 'Patient', id: "..."}).then(function(response){
    console.log(response);
}, function (error) {
    console.log(error);
});
```