### PR TITLE
Update Readme to use resource instead of content.

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,10 +165,10 @@ Here are implementations for:
 
 To create a FHIR resource, call
 `myClient.create(entry, callback, errback)`, passing
-an object that contains the following propperties:
+an object that contains the following properties:
 
-* `content` (required) - resource in FHIR json
-* `tags` (opttional) - list of categories (see below)
+* `resource` (required) - resource in FHIR json
+* `tags` (optional) - list of categories (see below)
 
 In case of success,the  callback function will be
 invoked with an object that contains the following
@@ -182,7 +182,7 @@ attributes:
 
 var entry = {
   category: [{term: 'TAG term', schema: 'TAG schema', label: 'TAG label'}, ...]
-  content: {
+  resource: {
     resourceType: 'Patient',
     //...
   }


### PR DESCRIPTION
The fhir client uses `resourceTypePath` as a resolver for create action (https://github.com/FHIR/fhir.js/blob/master/src/fhir.js#L44), hence it is be `resource` instead of content to create resources