### PR TITLE
include use : instead of .

### DIFF
--- a/src/middlewares/search.js
+++ b/src/middlewares/search.js
@@ -80,14 +80,14 @@
                     return v.map(function(x) {
                         return {
                             param: '_include',
-                            value: k + "." + x
+                            value: k + ":" + x
                         };
                     });
                 case 'string':
                     return [
                         {
                             param: '_include',
-                            value: k + "." + v
+                            value: k + ":" + v
                         }
                     ];
                 }
@@ -140,14 +140,15 @@
     };
 
     var buildSearchParams = function(query) {
-        var p, ps;
+        var p, ps, value;
         ps = (function() {
             var i, len, ref, results;
             ref = linearizeParams(query);
             results = [];
             for (i = 0, len = ref.length; i < len; i++) {
                 p = ref[i];
-                results.push([p.param, p.modifier, '=', p.operator, encodeURIComponent(p.value)].filter(identity).join(''));
+                value =  p.param === '_include' ? p.value : encodeURIComponent(p.value);
+                results.push([p.param, p.modifier, '=', p.operator, value].filter(identity).join(''));
             }
             return results;
         })();

--- a/test/querySpec.coffee
+++ b/test/querySpec.coffee
@@ -62,8 +62,8 @@ describe "test params builder", ->
 
 
   it "include", ->
-    assert.deepEqual(subject($include: {Observation: "related.component", Patient: ["link.other", "careProvider"]}),
-      '_include=Observation.related.component&_include=Patient.link.other&_include=Patient.careProvider')
+    assert.deepEqual(subject($include: {Observation: "related:component", Patient: ["link:other", "careProvider"]}),
+      '_include=Observation:related:component&_include=Patient:link:other&_include=Patient:careProvider')
 
   it "or", ->
     assert.deepEqual(subject(name: {$or: ['bill', 'ted']}),


### PR DESCRIPTION
Hello,
This PR aims to replace `:` by `.` in resource path when doing an `$include`

Not 100% sure on this one, but here what I found in the docs:
- https://www.hl7.org/implement/standards/FHIR/search.html#revinclude

> Parameter values for both _include and _revinclude have three parts, separated by a : character:

- This test server also uses this format: https://fhirtest.uhn.ca/search?serverId=home_21&pretty=true&resource=Observation&param.0.qualifier=&param.0.0=&param.0.name=_language&param.0.type=string&_include=Observation%3Abased-on&sort_by=&sort_direction=&resource-search-limit=