### PR TITLE
Fix failing node adapter if host is unreachable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ npm-debug.log
 *.term-port
 .term-port
 src/.tern-port
+.idea/
+*.iml

--- a/src/adapters/node.js
+++ b/src/adapters/node.js
@@ -27,16 +27,19 @@
               args.url = '/';
             }
             args.json = true;
-            if(args.debug){
-                console.log('DEBUG[node]: (requrest)', args); 
+            if(args.debug) {
+                console.log('DEBUG[node]: (request)', args);
             }
             request(args, function(err, response, body) {
                 var headers = function(x) {return response.headers[x.toLowerCase()];};
-                var resp = {data: body, status: response.statusCode, headers: headers, config: args};
+                var statusCode = response ? response.statusCode : 500; // in case host is unreachable
+
+                var resp = {data: body, status: statusCode, headers: headers, config: args};
+
                 if(args.debug){
-                    console.log('DEBUG[node]: (responce)', resp); 
+                    console.log('DEBUG[node]: (response)', resp);
                 }
-                if (err || response.statusCode > 399) {deff.reject(resp);} else {deff.resolve(resp);}
+                if (err || statusCode > 399) {deff.reject(resp);} else {deff.resolve(resp);}
             }) ;
             return deff.promise;
         }

--- a/test/nodeAdapterSpec.coffee
+++ b/test/nodeAdapterSpec.coffee
@@ -1,7 +1,7 @@
 http = require("http");
 assert = require('assert')
 
-responces =
+responses =
   '_defaults':
     'status': 200
     'headers': 'Content-Type': 'application/json'
@@ -32,9 +32,9 @@ responces =
 
 
 server = http.createServer (request, response) ->
-  defaults = responces._defaults
+  defaults = responses._defaults
   key = "#{request.method} #{request.url}"
-  resp = responces[key] || {
+  resp = responses[key] || {
     body: "#{key} not found"
     status: 404
   }
@@ -87,3 +87,18 @@ describe "nodejs adapter", ->
         done(e)
 
     subject.search({type: 'Patient', query: {name: 'adams'}}).then(success, fail)
+
+  it "should return 500 if host unreachable", (done)->
+    subject = fhir(baseUrl: 'http://wwww.exampleinvalidqqq.com/', patient: '123', auth: {user: 'client', pass: 'secret'})
+
+    unexpectedSuccess = (res)-> done(new Error("Should fail, but got #{JSON.stringify(res)}"))
+
+    expectedFail =  (err)->
+      try
+        assert(err)
+        assert(err.status == 500)
+        done()
+      catch e
+        done(e)
+
+    subject.search({type: 'Patient', query: {name: 'adams'}}).then(unexpectedSuccess, expectedFail)


### PR DESCRIPTION
In case if host is unreable `res` object in request made in the adapter
is undefined.
Getting property `status` from it results in fail which can not be
handled poperly in client application causing a crash.

This commit detects this situation and assigns status code 500 to such
requests.