### PR TITLE
support for independent meta operations

### DIFF
--- a/src/fhir.js
+++ b/src/fhir.js
@@ -47,9 +47,8 @@
         var resourceTypeHxPath = resourceTypePath.slash("_history");
         var resourcePath = resourceTypePath.slash(":id || :resource.id");
         var resourceHxPath = resourcePath.slash("_history");
-        var vreadPath =  resourceHxPath.slash(":versionId || :resource.meta.versionId");
-        var resourceVersionPath = resourceHxPath.slash(":versionId || :resource.meta.versionId");
-        var metaTarget = BaseUrl.slash(":target.resourceType || :target.type").slash(":target.id").slash('_history').slash(':target.versionId');
+        var vreadPath =  resourcePath.slash(":versionId || :resource.meta.versionId");
+        var metaTarget = BaseUrl.slash(":target.resourceType || :target.type").slash(":target.id").slash(':target.versionId');
         
         var ReturnHeader = $$Header('Prefer', 'return=representation');
 

--- a/src/fhir.js
+++ b/src/fhir.js
@@ -49,6 +49,7 @@
         var resourceHxPath = resourcePath.slash("_history");
         var vreadPath =  resourceHxPath.slash(":versionId || :resource.meta.versionId");
         var resourceVersionPath = resourceHxPath.slash(":versionId || :resource.meta.versionId");
+        var metaTarget = BaseUrl.slash(":target.resourceType ").slash(":target.id")
 
         var ReturnHeader = $$Header('Prefer', 'return=representation');
 
@@ -67,6 +68,11 @@
             "delete": DELETE.and(resourcePath).and(ReturnHeader).end(http),
             create: POST.and(resourceTypePath).and(ReturnHeader).end(http),
             validate: POST.and(resourceTypePath.slash("_validate")).end(http),
+            meta: {
+                add: POST.and(metaTarget.slash("$meta-add")).end(http),
+                delete: POST.and(metaTarget.slash("$meta-delete")).end(http),
+                read: GET.and(metaTarget.slash("$meta")).end(http)
+            },
             search: GET.and(resourceTypePath).and(pt.$WithPatient).and(query.$SearchParams).and($Paging).end(http),
             update: PUT.and(resourcePath).and(ReturnHeader).end(http),
             nextPage: GET.and(bundle.$$BundleLinkUrl("next")).end(http),

--- a/src/fhir.js
+++ b/src/fhir.js
@@ -49,8 +49,8 @@
         var resourceHxPath = resourcePath.slash("_history");
         var vreadPath =  resourceHxPath.slash(":versionId || :resource.meta.versionId");
         var resourceVersionPath = resourceHxPath.slash(":versionId || :resource.meta.versionId");
-        var metaTarget = BaseUrl.slash(":target.resourceType || :target.type").slash(":target.id")
-
+        var metaTarget = BaseUrl.slash(":target.resourceType || :target.type").slash(":target.id").slash('_history').slash(':target.versionId');
+        
         var ReturnHeader = $$Header('Prefer', 'return=representation');
 
         var $Paging = Middleware(query.$Paging);

--- a/src/fhir.js
+++ b/src/fhir.js
@@ -49,7 +49,7 @@
         var resourceHxPath = resourcePath.slash("_history");
         var vreadPath =  resourceHxPath.slash(":versionId || :resource.meta.versionId");
         var resourceVersionPath = resourceHxPath.slash(":versionId || :resource.meta.versionId");
-        var metaTarget = BaseUrl.slash(":target.resourceType ").slash(":target.id")
+        var metaTarget = BaseUrl.slash(":target.resourceType || :target.type").slash(":target.id")
 
         var ReturnHeader = $$Header('Prefer', 'return=representation');
 

--- a/src/middlewares/url.js
+++ b/src/middlewares/url.js
@@ -7,6 +7,7 @@
 
     var get_in = function(obj, path){
         return path.split('.').reduce(function(acc,x){
+            if(x === 'versionId' && acc[x]){ return `_history/${acc[x]}` }
             if(acc == null || acc == undefined) { return null; }
             return acc[x];
         }, obj);
@@ -31,7 +32,7 @@
 
     var buildPathPart = function(pth, args){
         var k = evalExpr(pth.trim(), args);
-        if(k==null || k === undefined){ throw new Error("Parameter "+pth+" is required: " + JSON.stringify(args)); }
+        if((k==null || k === undefined) && pth.includes('target.versionId') == false){ throw new Error("Parameter "+pth+" is required: " + JSON.stringify(args)); }
         return k;
     };
 
@@ -42,6 +43,9 @@
     var Path = function(tkn, chain){
         //Chainable
         var new_chain = function(args){
+            if(chain && tkn.includes('target.versionId') && !args.target.versionId){
+                return chain(args);
+            }
             return ((chain && (chain(args) + "/")) || "") +  buildPathPart(tkn, args);
         };
         var ch = core.Attribute('url', new_chain);

--- a/src/middlewares/url.js
+++ b/src/middlewares/url.js
@@ -7,7 +7,7 @@
 
     var get_in = function(obj, path){
         return path.split('.').reduce(function(acc,x){
-            if(x === 'versionId' && acc[x]){ return `_history/${acc[x]}` }
+            if(x === 'versionId' && acc[x]){ return '_history/'+ acc[x] }
             if(acc == null || acc == undefined) { return null; }
             return acc[x];
         }, obj);

--- a/test/resourceSpec.coffee
+++ b/test/resourceSpec.coffee
@@ -68,28 +68,28 @@ describe "search:", ->
     res.delete(http: http, resource: resource)
 
   it "meta.add", (done)->
-    target = { id: '5', type: 'Patient'}
+    target = { id: '5', type: 'Patient', versionId: 1}
     resource = { resourceType: 'Parameters'}
     http = (q)->
       assert.deepEqual(q.data, JSON.stringify(resource))
       assert.deepEqual(q.method, 'POST')
-      assert.deepEqual(q.url, 'BASE/Patient/5/$meta-add')
+      assert.deepEqual(q.url, 'BASE/Patient/5/_history/1/$meta-add')
       done()
     res.meta.add(http: http, resource: resource, target: target);
 
   it "meta.delete", (done)->
-    target = { id: '5', resourceType: 'Patient'}
+    target = { id: '5', resourceType: 'Patient', versionId: 4}
     resource = { resourceType: 'Parameters'}
     http = (q)->
       assert.deepEqual(q.method, 'POST')
-      assert.deepEqual(q.url, 'BASE/Patient/5/$meta-delete')
+      assert.deepEqual(q.url, 'BASE/Patient/5/_history/4/$meta-delete')
       done()
     res.meta.delete(http: http, resource: resource, target: target)
 
   it "meta.read", (done)->
-    target = { id: '5', resourceType: 'Patient'}
+    target = { id: '5', resourceType: 'Patient', versionId: 2}
     http = (q)->
       assert.deepEqual(q.method, 'GET')
-      assert.deepEqual(q.url, 'BASE/Patient/5/$meta')
+      assert.deepEqual(q.url, 'BASE/Patient/5/_history/2/$meta')
       done()
     res.meta.read(http: http, target: target)

--- a/test/resourceSpec.coffee
+++ b/test/resourceSpec.coffee
@@ -20,6 +20,9 @@ describe "search:", ->
     assert.notEqual(res.vread, null)
     assert.notEqual(res.update, null)
     assert.notEqual(res.delete, null)
+    assert.notEqual(res.meta.add, null)
+    assert.notEqual(res.meta.delete, null)
+    assert.notEqual(res.meta.read, null)
 
   headers = mockHeaders
     'Content-Location': 'BASE/Patient/5'
@@ -63,3 +66,30 @@ describe "search:", ->
       assert.deepEqual(q.url, 'BASE/Patient/5')
       done()
     res.delete(http: http, resource: resource)
+
+  it "meta.add", (done)->
+    target = { id: '5', type: 'Patient'}
+    resource = { resourceType: 'Parameters'}
+    http = (q)->
+      assert.deepEqual(q.data, JSON.stringify(resource))
+      assert.deepEqual(q.method, 'POST')
+      assert.deepEqual(q.url, 'BASE/Patient/5/$meta-add')
+      done()
+    res.meta.add(http: http, resource: resource, target: target);
+
+  it "meta.delete", (done)->
+    target = { id: '5', resourceType: 'Patient'}
+    resource = { resourceType: 'Parameters'}
+    http = (q)->
+      assert.deepEqual(q.method, 'POST')
+      assert.deepEqual(q.url, 'BASE/Patient/5/$meta-delete')
+      done()
+    res.meta.delete(http: http, resource: resource, target: target)
+
+  it "meta.read", (done)->
+    target = { id: '5', resourceType: 'Patient'}
+    http = (q)->
+      assert.deepEqual(q.method, 'GET')
+      assert.deepEqual(q.url, 'BASE/Patient/5/$meta')
+      done()
+    res.meta.read(http: http, target: target)

--- a/test/urlSpec.coffee
+++ b/test/urlSpec.coffee
@@ -14,7 +14,7 @@ describe "Path",->
     p1 = p0.slash(":type")
     p2 = p1.slash(":id")
     p3 = p2.slash("_history")
-    p4 = p3.slash(":versionId")
+    p4 = p2.slash(":versionId")
 
     p5 = p0.slash(":type || :resource.resourceType")
 
@@ -26,3 +26,21 @@ describe "Path",->
     
     assert.deepEqual(apply(p5, {resource: {resourceType: 'Patient'}}).url, "BASE/Patient")
     assert.deepEqual(apply(p5, {type: 'Patient'}).url, "BASE/Patient")
+
+  it "build path & combine for $meta",->
+
+    p0 = Path("BASE")
+    p1 = p0.slash(":target.type || :target.resourceType")
+    p2 = p1.slash(":target.id")
+    p3 = p2.slash(":target.versionId")
+    p4 = p3.slash("$meta")
+
+    assert.deepEqual(apply(p0, {}).url, "BASE")
+    assert.deepEqual(apply(p1, {target: {type: 'Patient'}}).url, "BASE/Patient")
+    assert.deepEqual(apply(p1, {target: {resourceType: 'Patient'}}).url, "BASE/Patient")
+    assert.deepEqual(apply(p2, {target: {type: 'Patient',id: 5}}).url, "BASE/Patient/5")
+    assert.deepEqual(apply(p3, {target: {type: 'Patient',id: 5, versionId: 6}}).url, "BASE/Patient/5/_history/6")
+    assert.deepEqual(apply(p4, {target: {type: 'Patient',id: 5, versionId: 6}}).url, "BASE/Patient/5/_history/6/$meta")
+
+    assert.deepEqual(apply(p3, {target: {type: 'Patient',id: 5}}).url, "BASE/Patient/5")
+    assert.deepEqual(apply(p4, {target: {type: 'Patient',id: 5}}).url, "BASE/Patient/5/$meta")


### PR DESCRIPTION
In docs:  https://www.hl7.org/fhir/resource-operations.html#meta

**How does it work?** 
This PR consists of full support for independent meta operations.
According to the official fhir documentation, field `meta` of every resource can have its fields added, deleted and read on its own (without changing the versionId of the resource in case of adding/deleting), just by adding `$meta`/`$meta-add`/`$meta-delete` at the end of the URL

Considering that the state of the `meta` fields depends on the `versionId` of the resource, adding this feature requires giving the user an option of choosing which version of the resource is the user interested in and/or if they're interested only in the last version, so possible url options (for operation `$meta`) are 
`${BASE_URL}/${resourceType}/${id}/$meta`
`${BASE_URL}/${resourceType}/${id}/_history/${versionId}/$meta`

All $meta* operations are based **not** on the body of the chosen resource, but on the resourceType `Parameters`, which means that the `resourceType` or `id` fields are no longer available in the body of the request.

**Usage**
I added a new operation called `meta`, which is an object of 3 possibilities - `add`, `delete` and `read`.
They take as an argument an object with keys `resource` (which is the resource `Parameters` with changes the user wants to apply) and `target`(the actual target resource, of which `meta` field we're editing).
Key `target` is an object, which requires the user to provide `resourceType` and `id`, but leaves it up to user if they wish to provide `versionId` or not.
Example request: 
```
await fhirClient().meta.add({
  resource: parametersBody,
  target: { resourceType: 'Patient', id: '123456789', versionId: 5}
})
```
where `parametersBody` is (for example)
```
{
    resourceType: 'Parameters',
    parameter: [
      {
        name: 'meta',
        valueMeta: {
          tag: {
            system: 'https://system-of-choice.com',
            code: 'SUCCESS',
            display: 'N/A'
          }
        }
      }
    ]
  }
```

This operation pushes a new tag to meta.tag array in the resource `Patient/123456789/_history/5`

**ALSO**
I realise my solution is way less abstract than the code base, which might not satisfy fully the requirements. However I do believe it was necessary, since the support of resource versioning is being used only in VREAD and now META and even here, there is a big difference (in META we want it to be user's choice, in VREAD we still want the error to show when user fails provide `versionId`).

I'd like to also already answer a question concerning the change on line 50 of the fhir.js file (change in the variable `vreadPath`)- the customisation of the `versionId` required adding `_history` to the url a bit earlier in the code (whenever the user provides 'versionId'), which means we no longer have to add it with `.slash()` method. It changes nothing in the usage. 