### PR TITLE
surface strictSSL option

### DIFF
--- a/src/adapters/node.js
+++ b/src/adapters/node.js
@@ -1,52 +1,55 @@
-(function() {
-    var request = require('request');
-    var mkFhir = require('../fhir');
-    var Q = require('q');
+(function () {
+  var request = require('request');
+  var mkFhir = require('../fhir');
+  var Q = require('q');
 
-    var adapter = {
-        defer: Q.defer,
-        http: function(args) {
-            var deff = Q.defer();
-            if(args.data && typeof args.data === "string") {
-              // Setting args.json requires args.body to be a JSON as per request docs.
-              try {
-                args.body = JSON.parse(args.data);
-              }
-              catch (e) {
-                throw new Error('Failed to parse. Expected JSON data...');
-              }
-            }
-            else if (args.data) {
-              args.body = args.data;
-            }
-            // url should be relative to baseUrl.
-            if(args.url) {
-                args.url = args.url.replace(args.baseUrl, '');
-            }
-            if(args.url === '') {
-              args.url = '/';
-            }
-            args.json = true;
-            if(args.debug) {
-                console.log('DEBUG[node]: (request)', args);
-            }
-            request(args, function(err, response, body) {
-                var headers = function(x) {return response.headers[x.toLowerCase()];};
-                var statusCode = response ? response.statusCode : 500; // in case host is unreachable
-
-                var resp = {data: body, status: statusCode, headers: headers, config: args};
-
-                if(args.debug){
-                    console.log('DEBUG[node]: (response)', resp);
-                }
-                if (err || statusCode > 399) {deff.reject(resp);} else {deff.resolve(resp);}
-            }) ;
-            return deff.promise;
+  var adapter = {
+    defer: Q.defer,
+    http: function (args) {
+      var deff = Q.defer();
+      if (args.data && typeof args.data === "string") {
+        // Setting args.json requires args.body to be a JSON as per request docs.
+        try {
+          args.body = JSON.parse(args.data);
         }
-    };
+        catch (e) {
+          throw new Error('Failed to parse. Expected JSON data...');
+        }
+      }
+      else if (args.data) {
+        args.body = args.data;
+      }
+      // url should be relative to baseUrl.
+      if (args.url) {
+        args.url = args.url.replace(args.baseUrl, '');
+      }
+      if (args.url === '') {
+        args.url = '/';
+      }
+      args.json = true;
+      if (args.debug) {
+        console.log('DEBUG[node]: (request)', args);
+      }
+      if (args.strictSSL === 'false') {
+        args.strictSSL = false;
+      }
+      request(args, function (err, response, body) {
+        var headers = function (x) { return response.headers[x.toLowerCase()]; };
+        var statusCode = response ? response.statusCode : 500; // in case host is unreachable
 
-    module.exports = function(config) {
-        return mkFhir(config, adapter);
-    };
+        var resp = { data: body, status: statusCode, headers: headers, config: args };
+
+        if (args.debug) {
+          console.log('DEBUG[node]: (response)', resp);
+        }
+        if (err || statusCode > 399) { deff.reject(resp); } else { deff.resolve(resp); }
+      });
+      return deff.promise;
+    }
+  };
+
+  module.exports = function (config) {
+    return mkFhir(config, adapter);
+  };
 
 }).call(this);

--- a/src/middlewares/config.js
+++ b/src/middlewares/config.js
@@ -1,13 +1,13 @@
-(function() {
-    var copyAttr = function(from, to, attr){
-        var v =  from[attr];
-        if(v && !to[attr]) {to[attr] = v;}
+(function () {
+    var copyAttr = function (from, to, attr) {
+        var v = from[attr];
+        if (v && !to[attr]) { to[attr] = v; }
         return from;
     };
 
-    module.exports = function(cfg, adapter){
-        return function(h){
-            return function(args){
+    module.exports = function (cfg, adapter) {
+        return function (h) {
+            return function (args) {
                 copyAttr(cfg, args, 'baseUrl');
                 copyAttr(cfg, args, 'cache');
                 copyAttr(cfg, args, 'auth');
@@ -16,6 +16,7 @@
                 copyAttr(cfg, args, 'credentials');
                 copyAttr(cfg, args, 'headers');
                 copyAttr(cfg, args, 'agentOptions');
+                copyAttr(cfg, args, 'strictSSL');
                 copyAttr(adapter, args, 'defer');
                 copyAttr(adapter, args, 'http');
                 return h(args);


### PR DESCRIPTION
Add an option to set the request library's strictSSL option to `false`. Aids in testing local fhir servers without SSL certificates.