### PR TITLE
Docs: add read() function, with example

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ myClient.create(entry,
 ```
 
 #### Get resource
+
 To get one specific object from a resource (usually by id), call `fhir.read({type: resourceType})`. To specify the patient identifier, call `fhir.read({type: resourceType, patient: patientIdentifier})`
 
 Examples:

--- a/README.md
+++ b/README.md
@@ -201,6 +201,15 @@ myClient.create(entry,
 
 ```
 
+#### Get resource
+To get one specific object from a resource (usually by id), call `fhir.read({type: resourceType})`. To specify the patient identifier, call `fhir.read({type: resourceType, patient: patientIdentifier})`
+
+Examples:
+
+```js
+fhir.read({type: 'Patient', patient: '8673ee4f-e2ab-4077-ba55-4980f408773e'})
+```
+
 #### Search Resource
 
 To search a resource, call `fhir.search({type: resourceType, query: queryObject})`,


### PR DESCRIPTION
afaict, the `fhir.read()` function is not documented anywhere, but is crucial to getting a patient by id.